### PR TITLE
Update test docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM naturalhistorymuseum/ckantest:0.2
+FROM naturalhistorymuseum/ckantest:latest
 
 WORKDIR /base/src/ckanext-video
 


### PR DESCRIPTION
Use the "latest" tag for the test docker image instead of explicitly specifying a version number.